### PR TITLE
Fixed save option bug

### DIFF
--- a/JsonDB.js
+++ b/JsonDB.js
@@ -27,7 +27,7 @@
             self.loaded = true;
             util.log("[JsonDB] DataBase " + self.filename + " created.");
         }
-        this.saveOnPush = saveOnPush || true;
+        this.saveOnPush = ( typeof( saveOnPush ) == "boolean" ) ? saveOnPush : true;
         if (humanReadable) {
             this.humanReadable = humanReadable;
         }


### PR DESCRIPTION
Currently the save option always sets to true regardless to the parameter passed through since saveOnPush || true always will be true.

Got a 30,000x speed up after this change ;)