### PR TITLE
Remove util.log on loading/creating

### DIFF
--- a/JsonDB.js
+++ b/JsonDB.js
@@ -25,7 +25,6 @@
             mkdirp.sync(dirname);
             self.save(true);
             self.loaded = true;
-            util.log("[JsonDB] DataBase " + self.filename + " created.");
         }
         this.saveOnPush = ( typeof( saveOnPush ) == "boolean" ) ? saveOnPush : true;
         if (humanReadable) {
@@ -203,7 +202,6 @@
             var data = FS.readFileSync(this.filename, 'utf8');
             this.data = JSON.parse(data);
             this.loaded = true;
-            util.log("[JsonDB] DataBase " + this.filename + " loaded.");
         } catch (err) {
             var error = new DatabaseError("Can't Load Database", 1, err);
             error.inner = err;

--- a/JsonDB.js
+++ b/JsonDB.js
@@ -2,7 +2,6 @@
     "use strict";
     var FS = require('fs');
     var events = require('events');
-    var util = require('util');
     var JsonUtils = require("./lib/utils");
     var DBParentData = require("./lib/DBParentData");
     var DatabaseError = require("./lib/Errors").DatabaseError;


### PR DESCRIPTION
If someone really wants to see a message on reading/creating - it is easily implemented in the main application, while it's wrong when a library outputs something to console in production mode.

Thanks