### PR TITLE
Check for undefined property in processArray

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -10,7 +10,8 @@
      * @returns ArrayInfo|null
      */
     const processArray = function (property) {
-
+        if (typeof property === 'undefined') return null;
+        
         if (regexCache[property]) {
             return regexCache[property];
         }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -10,8 +10,10 @@
      * @returns ArrayInfo|null
      */
     const processArray = function (property) {
-        if (typeof property === 'undefined') return null;
-        
+        if (typeof property === 'undefined') {
+             return null;
+        }
+
         if (regexCache[property]) {
             return regexCache[property];
         }

--- a/test/test_01-utils.js
+++ b/test/test_01-utils.js
@@ -64,6 +64,11 @@ describe('Utils', function () {
             });
         });
 
+        it('should ignore an empty agument', function () {
+            var arrayInfo = Util.processArray(undefined);
+            expect(arrayInfo).to.be(null);
+        });
+
     });
 
 });


### PR DESCRIPTION
Fix crash upon accessing `undefined.trim` when an empty database is passed to processArray

Fixes #33