### PR TITLE
Add "types" field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.9.1",
   "description": "Database using JSON file as storage for Node.JS",
   "main": "dist/JsonDB.js",
+  "types": "dist/types/JsonDB.d.ts",
   "scripts": {
     "test": "jest --coverage",
     "build": "babel src --out-dir dist --extensions \".ts,.tsx\" && tsc --emitDeclarationOnly",


### PR DESCRIPTION
Gives the TypeScript compiler info on where to find types for the
package. Fixes #57.