### PR TITLE
feat(CustomPersistance): Added custom persistance

### DIFF
--- a/src/lib/JsonDBConfig.ts
+++ b/src/lib/JsonDBConfig.ts
@@ -1,21 +1,21 @@
 export interface JsonDBConfig {
-  filename: string,
+  filename: string | null,
   saveOnPush: boolean,
   humanReadable: boolean,
   separator: string
 }
 
 export class Config implements JsonDBConfig {
-  filename: string
+  filename: string | null
   humanReadable: boolean
   saveOnPush: boolean
   separator: string
 
 
-  constructor(filename: string, saveOnPush: boolean = true, humanReadable: boolean = false, separator: string = '/') {
+  constructor(filename: string | null, saveOnPush: boolean = true, humanReadable: boolean = false, separator: string = '/') {
     this.filename = filename
 
-    if (!filename.endsWith(".json")) {
+    if (filename !== null && !filename.endsWith(".json")) {
       this.filename += ".json"
     }
 

--- a/test/05-persistance.test.ts
+++ b/test/05-persistance.test.ts
@@ -1,0 +1,51 @@
+import { JsonDB } from '../src/JsonDB'
+import { KeyValue } from '../src/lib/Utils'
+import { DatabaseError } from '../src/lib/Errors'
+
+describe('JsonDB', () => {
+
+    describe('no save at all', () => {
+        const db = new JsonDB(null, false, true)
+
+        test('should ignore persistance', () => {
+            db.push('/test', 'abc')
+            const data = db.getData()
+            expect(data).toHaveProperty('test')
+        })
+    })
+
+    describe('custom saving method', () => {
+        let saved: KeyValue;
+
+        const db = new JsonDB(null, true, true, '/', data => {
+            // custom saving method
+            saved = data
+        })
+
+        test('should execute a custom saving method on push', () => {
+            db.push('/automatic', 'abc')
+            expect(saved).toHaveProperty('automatic')
+        })
+
+        test('should trigger the custom saving method', () => {
+            db.push('/manual', 'abc')
+            db.save()
+            expect(saved).toHaveProperty('manual')
+        })
+    })
+
+    test('should throw an error when trying to save without a custom saving method', () => {
+        const db = new JsonDB(null, false, true)
+        
+        try {
+            (function () {
+                db.save()
+            })()
+
+            throw Error('Function did not throw')
+        } catch (e) {
+            expect(e).toBeInstanceOf(DatabaseError)
+            expect(e).toHaveProperty('id', 2)
+        }
+    })
+})


### PR DESCRIPTION
This is an indirect way of adding localStorage support (https://github.com/Belphemur/node-json-db/issues/22) and more...

It's fully backward compatible and enables the user to:
- Disable the default file persistance behavior by passing `null` as a filename in the constructor
- Give a custom saving method by passing a `saveCallback` in the constructor, which can be used with `saveOnPush` and `save()`

Although there won't be any file to load data from, you can still use `resetData(data)` to initialize data.
And you can use `getData()` or `getData("/")` to get the full data.